### PR TITLE
Alternate source formats

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,7 @@ PANDOC_DOCX = pandoc \
 PANDOC_DOCX_DEPS = $(DOCX_TEMPLATE) $(BIB)
 
 PANDOC_MD_TO_HTML_DEPS = $(HTML_TEMPLATE) $(BIB)
+PANDOC_MD_BOOK_ARGS = support/book-metadata.yml support/shared-metadata.yml $(FRONT_MATTER) $(POST_FRONT_MATTER) $(CHAPTERS)
 PANDOC_MD_TO_HTML = pandoc \
 	-r markdown+footnotes+auto_identifiers+implicit_header_references \
 	--template=$(HTML_TEMPLATE) \
@@ -130,7 +131,6 @@ PANDOC_MD_TO_HTML = pandoc \
 	--mathjax \
 	--number-section \
 	--section-divs \
-PANDOC_MD_BOOK_ARGS = support/book-metadata.yml support/shared-metadata.yml $(FRONT_MATTER) $(POST_FRONT_MATTER) $(CHAPTERS)
 
 PANDOC_LATEX_TO_HTML_DEPS = $(HTML_TEMPLATE) $(BIB)
 PANDOC_LATEX_TO_HTML = pandoc \

--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,7 @@ webpage: $(FIGURES) website/book-html/$(BOOK_NAME_SLUG).en.html
 
 sitedeps: $(AUTO_JSON_FILES) $(LOCALE_YAML_FILES)
 	rsync -av --delete figures website/source/
+	rsync -av --delete media website/source/
 
 site: sitedeps
 	rsync -av --delete figures website/source/

--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,7 @@ PANDOC_LATEX_TO_HTML = pandoc \
 
 PANDOC_DOCX_BOOK_ARGS = $(CHAPTERS)
 PANDOC_DOCX_TO_HTML_DEPS = $(HTML_TEMPLATE)
-DOCX_HTML_CLEANUP = ./scripts/modify-citation-markup.rb | ./scripts/docx-images.rb
+DOCX_HTML_CLEANUP = ./scripts/modify-citation-markup.rb | ./scripts/docx-images.rb | ./scripts/remove-extra-sections.rb
 PANDOC_DOCX_TO_HTML = pandoc \
 	-r docx+auto_identifiers \
 	--template=$(HTML_TEMPLATE) \

--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,7 @@ PANDOC_DOCX_DEPS = $(DOCX_TEMPLATE) $(BIB)
 
 PANDOC_MD_TO_HTML_DEPS = $(HTML_TEMPLATE) $(BIB)
 PANDOC_MD_BOOK_ARGS = support/book-metadata.yml support/shared-metadata.yml $(FRONT_MATTER) $(POST_FRONT_MATTER) $(CHAPTERS)
+MD_HTML_CLEANUP = ./scripts/modify-citation-markup.rb
 PANDOC_MD_TO_HTML = pandoc \
 	-r markdown+footnotes+auto_identifiers+implicit_header_references \
 	--template=$(HTML_TEMPLATE) \
@@ -149,6 +150,7 @@ PANDOC_LATEX_TO_HTML = pandoc \
 
 PANDOC_DOCX_BOOK_ARGS = $(CHAPTERS)
 PANDOC_DOCX_TO_HTML_DEPS = $(HTML_TEMPLATE)
+DOCX_HTML_CLEANUP = ./scripts/modify-citation-markup.rb | ./scripts/docx-images.rb
 PANDOC_DOCX_TO_HTML = pandoc \
 	-r docx+auto_identifiers \
 	--template=$(HTML_TEMPLATE) \
@@ -164,6 +166,7 @@ PANDOC_DOCX_TO_HTML = pandoc \
 
 PANDOC_HTML_DEPS = $(PANDOC_$(SOURCE_FORMAT)_TO_HTML_DEPS)
 PANDOC_HTML = $(PANDOC_$(SOURCE_FORMAT)_TO_HTML)
+HTML_CLEANUP = $($(SOURCE_FORMAT)_HTML_CLEANUP)
 
 PANDOC_BOOK_ARGS = $(PANDOC_$(SOURCE_FORMAT)_BOOK_ARGS)
 
@@ -179,7 +182,7 @@ output/$(BOOK_NAME_SLUG).pdf: $(PANDOC_PDF_DEPS) $(PANDOC_BOOK_ARGS)
 
 website/book-html/$(BOOK_NAME_SLUG).en.html: $(PANDOC_HTML_DEPS) $(PANDOC_BOOK_ARGS)
 	$(PANDOC_HTML) \
-	-s $(PANDOC_BOOK_ARGS) | ./scripts/modify-citation-markup.rb > $@
+	-s $(PANDOC_BOOK_ARGS) | $(HTML_CLEANUP) > $@
 
 website/book-html/$(BOOK_NAME_SLUG).%.html: output/$(BOOK_NAME_SLUG)-translate.html
 	cat $< | TRANSLATE_TO="$*" ./scripts/translate.rb > $@

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@
 
 BOOK_NAME_SLUG = sample-book
 EDITION := open-review
+SOURCE_FORMAT?=MD
 .DEFAULT_GOAL := chapters
 .PRECIOUS: website/book-html/$(BOOK_NAME_SLUG).%.html
 
@@ -22,8 +23,12 @@ EDITION := open-review
 MEXT = md
 
 ## All markdown files in the working directory
-FRONT_MATTER = $(sort $(wildcard _[0-9][0-9]-*.$(MEXT)))
-CHAPTERS = $(sort $(wildcard [0-9][0-9]-*.$(MEXT)))
+MD_FRONT_MATTER = $(sort $(wildcard _[0-9][0-9]-*.$(MEXT)))
+MD_CHAPTERS = $(sort $(wildcard [0-9][0-9]-*.$(MEXT)))
+
+FRONT_MATTER = $($(SOURCE_FORMAT)_FRONT_MATTER)
+CHAPTERS?= $($(SOURCE_FORMAT)_CHAPTERS)
+
 BUILD_DIR = output
 
 ## Location of Pandoc support files.
@@ -112,7 +117,8 @@ PANDOC_DOCX = pandoc \
 
 PANDOC_DOCX_DEPS = $(DOCX_TEMPLATE) $(BIB)
 
-PANDOC_HTML = pandoc \
+PANDOC_MD_TO_HTML_DEPS = $(HTML_TEMPLATE) $(BIB)
+PANDOC_MD_TO_HTML = pandoc \
 	-r markdown+footnotes+auto_identifiers+implicit_header_references \
 	--template=$(HTML_TEMPLATE) \
 	--toc \
@@ -124,10 +130,41 @@ PANDOC_HTML = pandoc \
 	--mathjax \
 	--number-section \
 	--section-divs \
+PANDOC_MD_BOOK_ARGS = support/book-metadata.yml support/shared-metadata.yml $(FRONT_MATTER) $(POST_FRONT_MATTER) $(CHAPTERS)
 
-PANDOC_HTML_DEPS = $(HTML_TEMPLATE) $(BIB)
+PANDOC_LATEX_TO_HTML_DEPS = $(HTML_TEMPLATE) $(BIB)
+PANDOC_LATEX_TO_HTML = pandoc \
+	-r latex+auto_identifiers \
+	--template=$(HTML_TEMPLATE) \
+	--toc \
+	--toc-depth=4 \
+	--filter $(PANDOC_CROSSREF_PATH) \
+	--filter pandoc-citeproc --bibliography=$(BIB) --metadata link-citations=true \
+	--default-image-extension=svg \
+	-M chapters \
+	--mathjax \
+	--number-section \
+	--section-divs \
 
-PANDOC_BOOK_ARGS = support/book-metadata.yml support/shared-metadata.yml $(FRONT_MATTER) $(POST_FRONT_MATTER) $(CHAPTERS)
+PANDOC_DOCX_BOOK_ARGS = $(CHAPTERS)
+PANDOC_DOCX_TO_HTML_DEPS = $(HTML_TEMPLATE)
+PANDOC_DOCX_TO_HTML = pandoc \
+	-r docx+auto_identifiers \
+	--template=$(HTML_TEMPLATE) \
+	--toc \
+	--toc-depth=4 \
+	--filter $(PANDOC_CROSSREF_PATH) \
+	--filter pandoc-citeproc --metadata link-citations=true \
+	--default-image-extension=svg \
+	-M chapters \
+	--mathjax \
+	--section-divs \
+	--extract-media=. \
+
+PANDOC_HTML_DEPS = $(PANDOC_$(SOURCE_FORMAT)_TO_HTML_DEPS)
+PANDOC_HTML = $(PANDOC_$(SOURCE_FORMAT)_TO_HTML)
+
+PANDOC_BOOK_ARGS = $(PANDOC_$(SOURCE_FORMAT)_BOOK_ARGS)
 
 output/$(BOOK_NAME_SLUG).tex: $(PANDOC_PDF_DEPS) $(PANDOC_BOOK_ARGS)
 	$(PANDOC_PDF) \

--- a/scripts/docx-images.rb
+++ b/scripts/docx-images.rb
@@ -1,0 +1,19 @@
+#!/usr/bin/env ruby
+#
+# This script removes the styles from image attributes.
+#
+# Input the HTML document via STDIN and output will be via STDOUT.
+
+require 'rubygems'
+require 'bundler/setup'
+require 'nokogiri'
+require 'json'
+
+html = ARGF.read
+html_doc = Nokogiri::HTML(html)
+
+html_doc.css('img').each do |img|
+  img.attributes['style'].remove
+end
+
+print html_doc.to_html

--- a/scripts/remove-extra-sections.rb
+++ b/scripts/remove-extra-sections.rb
@@ -1,0 +1,27 @@
+#!/usr/bin/env ruby
+#
+# This script removes the styles from image attributes.
+#
+# Input the HTML document via STDIN and output will be via STDOUT.
+
+require 'rubygems'
+require 'bundler/setup'
+require 'nokogiri'
+require 'json'
+
+html = ARGF.read
+html_doc = Nokogiri::HTML(html)
+
+html_doc.css('.TOCHeading').each do |sec|
+  sec.remove
+end
+
+toc = html_doc.css("#TOC")
+toc_links = toc.css('li a:first-of-type')
+toc_links.each do |link|
+  if link.inner_html == '' or ['#table-of-contents', '#notes'].include? link['href']
+    link.remove
+  end
+end
+
+print html_doc.to_html

--- a/website/config.rb
+++ b/website/config.rb
@@ -42,7 +42,7 @@ activate :i18n, :mount_at_root => false, :langs => [:en]
 configure :build do
   # Minify CSS on build
   activate :minify_css
-  activate :asset_hash, ignore: ["figures/*", "fonts/bootstrap/*"]
+  activate :asset_hash, ignore: ["figures/*", "media/*", "fonts/bootstrap/*"]
 
   # Minify Javascript on build
   # activate :minify_javascript


### PR DESCRIPTION
Adds some initial support for having docx files as the input source rather than Markdown. There are a lot more variations with docx, so it isn't as much of a one-size fits all option as Markdown is.